### PR TITLE
clean up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,16 +25,16 @@ EXPOSE 80
 
 CMD ["./node_modules/@ionic/cli/bin/ionic", "serve","--host", "0.0.0.0", "--port", "80"]
 
-FROM python:3.13.2-alpine3.21 AS python
+FROM python:3.13.3-alpine3.21 AS python
 
 WORKDIR /usr/src/app
 
-COPY microservices/requirements.txt ./
+COPY data_grabber/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY microservices/ ./
+COPY data_grabber/ ./
 
-COPY microservices/.docker/python/entrypoint.sh /entrypoint.sh
+COPY data_grabber/.docker/python/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Set entrypoint

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -11,8 +11,8 @@ plugins:
     out: frontend/gen/ts
   - protoc_builtin: python
     protoc_path: '/usr/bin/protoc'
-    out: microservices/gen/python
+    out: data_grabber/gen/python
   - remote: buf.build/grpc/python:v1.71.0
-    out: microservices/gen/python
+    out: data_grabber/gen/python
 inputs:
   - directory: proto

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
 
   db:
     image: postgres
-    restart: always
+    restart: unless-stopped
     ports:
       - "5432:5432"
     environment:
@@ -50,11 +50,12 @@ services:
     build: 
       context: .
       target: python
+    restart: unless-stopped
     environment:
       SCRIPT_NAME:
       INTERNAL_SERVICE_AUTH_KEY:
     volumes:
-      - ./microservices:/usr/src/app
+      - ./data_grabber:/usr/src/app
     stdin_open: true
     tty: true
     network_mode: host


### PR DESCRIPTION
# Conflicts:
#	Dockerfile

diff --git a/Dockerfile b/Dockerfile
index 817487a..8e38009 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,16 +25,16 @@ EXPOSE 80

 CMD ["./node_modules/@ionic/cli/bin/ionic", "serve","--host", "0.0.0.0", "--port", "80"]

-FROM python:3.13.2-alpine3.21 AS python
+FROM python:3.13.3-alpine3.21 AS python

 WORKDIR /usr/src/app

-COPY microservices/requirements.txt ./
+COPY data_grabber/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt

-COPY microservices/ ./
+COPY data_grabber/ ./

-COPY microservices/.docker/python/entrypoint.sh /entrypoint.sh +COPY data_grabber/.docker/python/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

 # Set entrypoint
diff --git a/buf.gen.yaml b/buf.gen.yaml
index 9dab70b..923bfdf 100644
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -11,8 +11,8 @@ plugins:
     out: frontend/gen/ts
   - protoc_builtin: python protoc_path: '/usr/bin/protoc'
-    out: microservices/gen/python
+    out: data_grabber/gen/python
   - remote: buf.build/grpc/python:v1.71.0
-    out: microservices/gen/python
+    out: data_grabber/gen/python
 inputs:
   - directory: proto
\ No newline at end of file
diff --git a/docker-compose.yml b/docker-compose.yml
index 74416c0..51c41e9 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:

   db:
     image: postgres
-    restart: always
+    restart: unless-stopped
     ports:
       - "5432:5432"
     environment:
@@ -50,11 +50,12 @@ services:
     build:
       context: .
       target: python
+    restart: unless-stopped
     environment:
       SCRIPT_NAME:
       INTERNAL_SERVICE_AUTH_KEY:
     volumes:
-      - ./microservices:/usr/src/app
+      - ./data_grabber:/usr/src/app
     stdin_open: true
     tty: true
     network_mode: host
diff --git a/microservices b/microservices
deleted file mode 160000
index 750c262..0000000
--- a/microservices
+++ /dev/null
@@ -1 +0,0 @@
-Subproject commit 750c262e3a158711c9784ad1a4b4a2466853bc16